### PR TITLE
졸업시험 데이터 테이블 변경에 따른 파싱 코드 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,10 +22,13 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
+    implementation 'org.springframework.boot:spring-boot-starter-test'
+    compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	implementation 'com.google.code.gson:gson:2.9.0'
+	implementation 'org.testng:testng:7.1.0'
+	implementation 'org.junit.jupiter:junit-jupiter:5.8.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/wiseSWlife/wiseSWlife/service/graduation/scrapping/Exam.java
+++ b/src/main/java/wiseSWlife/wiseSWlife/service/graduation/scrapping/Exam.java
@@ -14,7 +14,6 @@ import java.util.Map;
 @Service
 @RequiredArgsConstructor
 public class Exam {
-
     public Map<String, Boolean> scrapping(String intCookie) throws IOException, InterruptedException {
         String command = "C:\\Users\\User\\PycharmProjects\\pythonProjectVenv\\venv\\Scripts\\python.exe"; //명령어
         String arg1 = "C:\\Users\\User\\PycharmProjects\\pythonProjectVenv\\Wife_SW_Life\\login.py";//인지
@@ -41,24 +40,32 @@ public class Exam {
         }
 
         String testLine = br.readLine();
-
         GsonBuilder builder1 = new GsonBuilder();
         builder1.setPrettyPrinting();
         Gson gson = builder1.create();
 
         ExamTable examTable = gson.fromJson(testLine,ExamTable.class);
+        Map<String, Boolean> examMap = examParsing(examTable);
 
+        return examMap;
+    }
+
+    private Map<String, Boolean> examParsing(ExamTable examTable) {
         Map<String, Boolean> examMap = new HashMap<>();
+        String[] subjects = {"성경", "영어", "컴퓨터", "컴퓨터2"};
+
+        for(String i : subjects){
+            examMap.put(i, false);
+        }
 
         for(ArrayList i:examTable.getBody()){
-            if(i.get(4).equals("합격자 신청 불가")){
-                examMap.put(i.get(2).toString(),true);
+            if(i.get(4).equals("합격")){
+                examMap.put(i.get(1).toString(),true);
             }
             else{
-                examMap.put(i.get(2).toString(),false);
+                examMap.put(i.get(1).toString(),false);
             }
         }
         return examMap;
     }
-
 }

--- a/src/test/java/wiseSWlife/wiseSWlife/service/graduation/login/LoginServiceTest.java
+++ b/src/test/java/wiseSWlife/wiseSWlife/service/graduation/login/LoginServiceTest.java
@@ -1,0 +1,30 @@
+package wiseSWlife.wiseSWlife.service.graduation.login;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import wiseSWlife.wiseSWlife.db.entity.memberRepository.MemoryMemberRepository;
+import wiseSWlife.wiseSWlife.db.repository.memberRepository.MemberRepository;
+import wiseSWlife.wiseSWlife.model.member.Member;
+import wiseSWlife.wiseSWlife.service.login.loginServiceImpl.SimpleLoginService;
+
+import static org.assertj.core.api.Assertions.*;
+import java.io.IOException;
+
+public class LoginServiceTest {
+    MemberRepository memberRepository = new MemoryMemberRepository();
+    SimpleLoginService simpleLoginService = new SimpleLoginService(memberRepository);
+
+    @DisplayName("로그인 여부")
+    @Test
+    void LoginTest() throws IOException, InterruptedException {
+        //given
+
+        //when
+        Member member = simpleLoginService.login("아이디", "비밀번호");
+
+        //then
+        assertThat(member).isNotNull();
+    }
+
+
+}

--- a/src/test/java/wiseSWlife/wiseSWlife/service/graduation/scraping/ExamTest.java
+++ b/src/test/java/wiseSWlife/wiseSWlife/service/graduation/scraping/ExamTest.java
@@ -1,0 +1,47 @@
+package wiseSWlife.wiseSWlife.service.graduation.scraping;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import wiseSWlife.wiseSWlife.db.entity.memberRepository.MemoryMemberRepository;
+import wiseSWlife.wiseSWlife.db.repository.memberRepository.MemberRepository;
+import wiseSWlife.wiseSWlife.model.member.Member;
+import wiseSWlife.wiseSWlife.service.graduation.scrapping.Exam;
+import wiseSWlife.wiseSWlife.service.login.loginServiceImpl.SimpleLoginService;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ExamTest {
+    MemberRepository memberRepository = new MemoryMemberRepository();
+    SimpleLoginService simpleLoginService = new SimpleLoginService(memberRepository);
+
+    @DisplayName("로그인 여부")
+    @Test
+    void LoginTest() throws IOException, InterruptedException {
+        //given
+
+        //when
+        Member member = simpleLoginService.login("아이디", "비밀번호");
+
+        //then
+        assertThat(member).isNotNull();
+    }
+
+
+    @DisplayName("졸업 시험 합/불 테스트")
+    @Test
+    void examScrapingDataSetTest() throws IOException, InterruptedException {
+        //given
+        Member member = simpleLoginService.login("아이디", "비밀번호");
+        Exam exam = new Exam();
+
+        //when
+        Map<String, Boolean> testMap = exam.scrapping(member.getIntCookie());
+
+        //then
+        assertThat(testMap.get("성경")).isFalse();
+
+    }
+}


### PR DESCRIPTION
인트라넷의 졸업시험 데이터가 변경되었습니다.

그에 따라 scapingAPI의 코드를 [수정 요청](https://github.com/rekyungmin/biblebot-scraper/pull/21)하였고

바뀐 데이터 테이블의 파싱 코드를 변경합니다.

> 바뀐 데이터 셋 확인은 위 링크 참고
