### PR TITLE
propertise 파일 리팩토링

### DIFF
--- a/UsersUserPycharmProjectspythonProjectVenvWife_SW_Lifelogin.py
+++ b/UsersUserPycharmProjectspythonProjectVenvWife_SW_Lifelogin.py
@@ -1,0 +1,10 @@
+import asyncio
+
+from biblebot import IntranetAPI
+
+async def main():
+    resp = await IntranetAPI.GraduationExam.fetch(cookies={'ASP.NET_SessionId': '31wt31alaphdhh45skymsx45'})
+    result = IntranetAPI.GraduationExam.parse(resp)
+    responseData = dict(result.data.items())
+    print(responseData)
+asyncio.run(main())

--- a/UsersUserPycharmProjectspythonProjectVenvWife_SW_Lifelogin.py
+++ b/UsersUserPycharmProjectspythonProjectVenvWife_SW_Lifelogin.py
@@ -3,8 +3,8 @@ import asyncio
 from biblebot import IntranetAPI
 
 async def main():
-    resp = await IntranetAPI.GraduationExam.fetch(cookies={'ASP.NET_SessionId': '31wt31alaphdhh45skymsx45'})
-    result = IntranetAPI.GraduationExam.parse(resp)
+    resp = await IntranetAPI.TotalAcceptanceStatus.fetch(cookies={'ASP.NET_SessionId': 'xu1lnhv53wgzmg45uhbmtlrv'})
+    result = IntranetAPI.TotalAcceptanceStatus.parse(resp)
     responseData = dict(result.data.items())
     print(responseData)
 asyncio.run(main())

--- a/src/main/java/wiseSWlife/wiseSWlife/service/graduation/scrapping/Exam.java
+++ b/src/main/java/wiseSWlife/wiseSWlife/service/graduation/scrapping/Exam.java
@@ -3,6 +3,7 @@ package wiseSWlife.wiseSWlife.service.graduation.scrapping;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import wiseSWlife.wiseSWlife.model.graduation.ExamTable;
 
@@ -14,11 +15,17 @@ import java.util.Map;
 @Service
 @RequiredArgsConstructor
 public class Exam {
-    public Map<String, Boolean> scrapping(String intCookie) throws IOException, InterruptedException {
-        String command = "C:\\Users\\User\\PycharmProjects\\pythonProjectVenv\\venv\\Scripts\\python.exe"; //명령어
-        String arg1 = "C:\\Users\\User\\PycharmProjects\\pythonProjectVenv\\Wife_SW_Life\\login.py";//인지
+    @Value("${python.engine}")
+    String pythonEngine;
 
-        File testFile = new File(arg1);
+    @Value("${python.file}")
+    String pythonFile;
+
+    @Value("${python.encoding}")
+    String pythonEncoding;
+
+    public Map<String, Boolean> scrapping(String intCookie) throws IOException, InterruptedException {
+        File testFile = new File(pythonFile);
         FileWriter fw = new FileWriter(testFile);
         fw.write("import asyncio\n" + "\n");
         fw.write("from biblebot import IntranetAPI\n" + "\n");
@@ -31,10 +38,10 @@ public class Exam {
         fw.flush();
         fw.close();
 
-        ProcessBuilder builder = new ProcessBuilder(command, arg1);
+        ProcessBuilder builder = new ProcessBuilder(pythonEngine, pythonFile);
         Process process = builder.start();
         int exitVal = process.waitFor();//자식 프로세스가 종료될 때까지 기다림
-        BufferedReader br = new BufferedReader(new InputStreamReader(process.getInputStream(), "euc-kr")); // 서브 프로세스가 출력하는 내용을 받기 위해
+        BufferedReader br = new BufferedReader(new InputStreamReader(process.getInputStream(), pythonEncoding)); // 서브 프로세스가 출력하는 내용을 받기 위해
         if(exitVal != 0) {//비정상적으로 종료시
             System.out.println("서브 프로세스가 비정상 종료되었습니다.");
         }

--- a/src/main/java/wiseSWlife/wiseSWlife/service/graduation/scrapping/TotalAcceptanceStatus.java
+++ b/src/main/java/wiseSWlife/wiseSWlife/service/graduation/scrapping/TotalAcceptanceStatus.java
@@ -3,6 +3,7 @@ package wiseSWlife.wiseSWlife.service.graduation.scrapping;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import wiseSWlife.wiseSWlife.model.graduation.TotalAcceptanceStatusTable;
 
@@ -11,12 +12,17 @@ import java.io.*;
 @Service
 @RequiredArgsConstructor
 public class TotalAcceptanceStatus {
+    @Value("${python.engine}")
+    String pythonEngine;
+
+    @Value("${python.file}")
+    String pythonFile;
+
+    @Value("${python.encoding}")
+    String pythonEncoding;
 
     public TotalAcceptanceStatusTable scrapping(String intCookie) throws IOException, InterruptedException {
-        String command = "C:\\Users\\User\\PycharmProjects\\pythonProjectVenv\\venv\\Scripts\\python.exe"; //명령어
-        String arg1 = "C:\\Users\\User\\PycharmProjects\\pythonProjectVenv\\Wife_SW_Life\\login.py";//인지
-
-        File testFile = new File(arg1);
+        File testFile = new File(pythonFile);
         FileWriter fw = new FileWriter(testFile);
         fw.write("import asyncio\n" + "\n");
         fw.write("from biblebot import IntranetAPI\n" + "\n");
@@ -29,10 +35,10 @@ public class TotalAcceptanceStatus {
         fw.flush();
         fw.close();
 
-        ProcessBuilder builder = new ProcessBuilder(command, arg1);
+        ProcessBuilder builder = new ProcessBuilder(pythonEngine, pythonFile);
         Process process = builder.start();
         int exitVal = process.waitFor();//자식 프로세스가 종료될 때까지 기다림
-        BufferedReader br = new BufferedReader(new InputStreamReader(process.getInputStream(), "euc-kr")); // 서브 프로세스가 출력하는 내용을 받기 위해
+        BufferedReader br = new BufferedReader(new InputStreamReader(process.getInputStream(), pythonEncoding)); // 서브 프로세스가 출력하는 내용을 받기 위해
         if(exitVal != 0) {//비정상적으로 종료시
             System.out.println("서브 프로세스가 비정상 종료되었습니다.");
         }

--- a/src/main/java/wiseSWlife/wiseSWlife/service/graduation/standardImpl/Standard2017.java
+++ b/src/main/java/wiseSWlife/wiseSWlife/service/graduation/standardImpl/Standard2017.java
@@ -2,6 +2,7 @@ package wiseSWlife.wiseSWlife.service.graduation.standardImpl;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
 import org.springframework.stereotype.Service;
 import wiseSWlife.wiseSWlife.model.graduation.form.CreditForm;
 import wiseSWlife.wiseSWlife.model.graduation.form.GPAForm;
@@ -13,6 +14,7 @@ import java.util.ArrayList;
 
 @Service
 @RequiredArgsConstructor
+@PropertySource("graduation.properties")
 public class Standard2017 implements Standard {
 
     @Value("${totalCredit.2017}")
@@ -21,10 +23,10 @@ public class Standard2017 implements Standard {
     @Value("${totalGPA.2017}")
     String totalGPA;//졸업기준 평균평점
 
-    @Value("24")
+    @Value("${totalMajorRequirement.2017}")
     String totalMajorRequirement;//전공필수 총학점
 
-    @Value("66")
+    @Value("${totalCommonMajor.2017}")
     String totalCommonMajor;//기본전공 총학점
 
     @Override

--- a/src/main/java/wiseSWlife/wiseSWlife/service/login/loginServiceImpl/SimpleLoginService.java
+++ b/src/main/java/wiseSWlife/wiseSWlife/service/login/loginServiceImpl/SimpleLoginService.java
@@ -3,6 +3,7 @@ package wiseSWlife.wiseSWlife.service.login.loginServiceImpl;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import wiseSWlife.wiseSWlife.service.login.loginServiceInterface.LoginService;
 import wiseSWlife.wiseSWlife.model.member.Member;
@@ -13,15 +14,20 @@ import java.io.*;
 @Service
 @RequiredArgsConstructor
 public class SimpleLoginService implements LoginService {
+    @Value("${python.engine}")
+    String pythonEngine;
+
+    @Value("${python.file}")
+    String pythonFile;
+
+    @Value("${python.encoding}")
+    String pythonEncoding;
+
     private final MemberRepository memberRepository;
 
     @Override
     public Member login(String loginId, String password) throws IOException, InterruptedException {
-
-        String command = "C:\\Users\\User\\PycharmProjects\\pythonProjectVenv\\venv\\Scripts\\python.exe"; //명령어
-        String arg1 = "C:\\Users\\User\\PycharmProjects\\pythonProjectVenv\\Wife_SW_Life\\login.py";//인지
-
-        File testFile = new File(arg1);
+        File testFile = new File(pythonFile);
         FileWriter fw = new FileWriter(testFile);
         fw.write("import asyncio\n" + "\n");
         fw.write("from biblebot import IntranetAPI\n" + "\n");
@@ -38,10 +44,10 @@ public class SimpleLoginService implements LoginService {
         fw.flush();
         fw.close();
 
-        ProcessBuilder builder = new ProcessBuilder(command, arg1);
+        ProcessBuilder builder = new ProcessBuilder(pythonEngine, pythonFile);
         Process process = builder.start();
         int exitVal = process.waitFor();//자식 프로세스가 종료될 때까지 기다림
-        BufferedReader br = new BufferedReader(new InputStreamReader(process.getInputStream(), "euc-kr")); // 서브 프로세스가 출력하는 내용을 받기 위해
+        BufferedReader br = new BufferedReader(new InputStreamReader(process.getInputStream(), pythonEncoding)); // 서브 프로세스가 출력하는 내용을 받기 위해
         if(exitVal != 0) {//비정상적으로 종료시
             System.out.println("서브 프로세스가 비정상 종료되었습니다.");
         }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,5 +4,6 @@ server.servlet.session.timeout=900
 spring.messages.encoding=UTF-8
 
 
-totalCredit.2017=140
-totalGPA.2017=1.5
+python.engine=C:\\Users\\User\\PycharmProjects\\pythonProjectVenv\\venv\\Scripts\\python.exe
+python.file=C:\Users\User\PycharmProjects\pythonProjectVenv\Wife_SW_Life\login.py
+python.encoding=euc-kr

--- a/src/main/resources/graduation.properties
+++ b/src/main/resources/graduation.properties
@@ -1,0 +1,5 @@
+totalCredit.2017=140
+totalGPA.2017=1.5
+totalMajorRequirement.2017=24
+totalCommonMajor.2017=66
+totalEnglish.2017=4


### PR DESCRIPTION
### 1. python 파일을 실행시 각각의 경로가 달라 pull시 conflict 발생

**[ 문제점 ]**
기존 파이썬 engine경로, file경로, encoding을 string으로 선언하여 사용했으나 각각의 pythone엔진과 file의 경로가 달라 pull할 경우에 충돌이 발생하였고, pull 후에는 경로를 수동으로 수정해주었어야했습니다. 또한 Window와 Mac의 Encoding이 달라 이것 또한 pull할 경우에 수동으로 수정을 해주었어야 했다.

**[ 해결 ]**
기존 파이썬 engine경로, file경로, encoding을 application.propertise로 설정해주어 경로의 충돌을 해결하였습니다.

### 2. application.properties 분류

**[ 문제점 ]**
기존에 application.properties에서 졸업요건 점검에 관한 상수들을 관리하였습니다. 하지만 applicaion.properties에서는 어떤 하나의 service에 대한 상수를 관리하는 파일이 아니라 전체적인 서비스의 상수를 관리하는 것이 맞다고 생각합니다.

**[ 해결 ]**
기존 application.properties에 있는 졸업요건 점검에 관한 상수들을 graduation.properties로 변경해주었습니다.
application.properties가 아닌 properties파일들은 DI를 해주어야하므로 @PropertySource를 사용하여 의존성 주입을 해주었습니다.


++ application.properties파일을 자신의 경로로 바꾸시고 이후 commit에는 application.properties파일을 올리지 않는 것으로 하겠습니다.